### PR TITLE
Enable Support foundation ID in service-broker routes to identify cloud foundry instance

### DIFF
--- a/src/main/java/org/springframework/cloud/servicebroker/controller/CatalogController.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/controller/CatalogController.java
@@ -22,7 +22,8 @@ public class CatalogController extends BaseController {
 		super(service);
 	}
 
-	@RequestMapping(value = "/v2/catalog", method = RequestMethod.GET)
+	@RequestMapping(value = {"/v2/catalog", "{foundationId}/v2/catalog"},
+		method = RequestMethod.GET)
 	public Catalog getCatalog() {
 		log.debug("getCatalog()");
 		return catalogService.getCatalog();

--- a/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingController.java
@@ -28,7 +28,6 @@ import javax.validation.Valid;
  * @author sgreenberg@pivotal.io
  */
 @RestController
-@RequestMapping("/v2/service_instances/{instanceId}/service_bindings/{bindingId}")
 @Slf4j
 public class ServiceInstanceBindingController extends BaseController {
 
@@ -41,7 +40,15 @@ public class ServiceInstanceBindingController extends BaseController {
 		this.serviceInstanceBindingService = serviceInstanceBindingService;
 	}
 
-	@RequestMapping(method = RequestMethod.PUT)
+	@RequestMapping(value = "/{foundationId}/v2/service_instances/{instanceId}/service_bindings/{bindingId}", method = RequestMethod.PUT)
+	public ResponseEntity<?> createServiceInstanceBinding(@PathVariable("foundationId") String foundationId,
+														  @PathVariable("instanceId") String serviceInstanceId,
+														  @PathVariable("bindingId") String bindingId,
+														  @Valid @RequestBody CreateServiceInstanceBindingRequest request) {
+		return createServiceInstanceBinding(serviceInstanceId, bindingId, request.withFoundationId(foundationId));
+	}
+
+	@RequestMapping(value = "/v2/service_instances/{instanceId}/service_bindings/{bindingId}", method = RequestMethod.PUT)
 	public ResponseEntity<?> createServiceInstanceBinding(@PathVariable("instanceId") String serviceInstanceId,
 														  @PathVariable("bindingId") String bindingId,
 														  @Valid @RequestBody CreateServiceInstanceBindingRequest request) {
@@ -62,8 +69,10 @@ public class ServiceInstanceBindingController extends BaseController {
 		return new ResponseEntity<>(response, response.isBindingExisted() ? HttpStatus.OK : HttpStatus.CREATED);
 	}
 
-	@RequestMapping(method = RequestMethod.DELETE)
-	public ResponseEntity<String> deleteServiceInstanceBinding(@PathVariable("instanceId") String serviceInstanceId,
+
+	@RequestMapping(value = "/{foundationId}/v2/service_instances/{instanceId}/service_bindings/{bindingId}", method = RequestMethod.DELETE)
+	public ResponseEntity<String> deleteServiceInstanceBinding(@PathVariable("foundationId") String foundationId,
+															   @PathVariable("instanceId") String serviceInstanceId,
 															   @PathVariable("bindingId") String bindingId,
 															   @RequestParam("service_id") String serviceDefinitionId,
 															   @RequestParam("plan_id") String planId) {
@@ -71,13 +80,37 @@ public class ServiceInstanceBindingController extends BaseController {
 				+ "serviceInstanceId=" + serviceInstanceId
 				+ ", bindingId=" + bindingId
 				+ ", serviceDefinitionId=" + serviceDefinitionId
+				+ ", planId=" + planId
+				+ ", foundationId=" + foundationId);
+
+		DeleteServiceInstanceBindingRequest request =
+				new DeleteServiceInstanceBindingRequest(serviceInstanceId, bindingId, serviceDefinitionId, planId,
+						getServiceDefinition(serviceDefinitionId));
+
+		return deleteServiceInstanceBinding(bindingId, request.withFoundationId(foundationId));
+	}
+
+	@RequestMapping(value = "/v2/service_instances/{instanceId}/service_bindings/{bindingId}", method = RequestMethod.DELETE)
+	public ResponseEntity<String> deleteServiceInstanceBinding(@PathVariable("instanceId") String serviceInstanceId,
+															   @PathVariable("bindingId") String bindingId,
+															   @RequestParam("service_id") String serviceDefinitionId,
+															   @RequestParam("plan_id") String planId) {
+		DeleteServiceInstanceBindingRequest request =
+				new DeleteServiceInstanceBindingRequest(serviceInstanceId, bindingId, serviceDefinitionId, planId,
+						getServiceDefinition(serviceDefinitionId));
+
+		log.debug("Deleting a service instance binding: "
+				+ "serviceInstanceId=" + serviceInstanceId
+				+ ", bindingId=" + bindingId
+				+ ", serviceDefinitionId=" + serviceDefinitionId
 				+ ", planId=" + planId);
 
-		try {
-			DeleteServiceInstanceBindingRequest request =
-					new DeleteServiceInstanceBindingRequest(serviceInstanceId, bindingId, serviceDefinitionId, planId,
-							getServiceDefinition(serviceDefinitionId));
+		return deleteServiceInstanceBinding(bindingId, request);
+	}
 
+	private ResponseEntity<String> deleteServiceInstanceBinding(String bindingId,
+																DeleteServiceInstanceBindingRequest request) {
+		try {
 			serviceInstanceBindingService.deleteServiceInstanceBinding(request);
 		} catch (ServiceInstanceBindingDoesNotExistException e) {
 			log.debug("Service instance binding does not exist: " + e);

--- a/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceController.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceController.java
@@ -37,7 +37,6 @@ import javax.validation.Valid;
  * @author Scott Frederick
  */
 @RestController
-@RequestMapping("/v2/service_instances/{instanceId}")
 @Slf4j
 public class ServiceInstanceController extends BaseController {
 
@@ -49,7 +48,7 @@ public class ServiceInstanceController extends BaseController {
 		this.service = serviceInstanceService;
 	}
 
-	@RequestMapping(method = RequestMethod.PUT)
+	@RequestMapping(value = "/v2/service_instances/{instanceId}", method = RequestMethod.PUT)
 	public ResponseEntity<?> createServiceInstance(@PathVariable("instanceId") String serviceInstanceId,
 												   @Valid @RequestBody CreateServiceInstanceRequest request,
 												   @RequestParam(value = "accepts_incomplete", required = false) boolean acceptsIncomplete) {
@@ -68,6 +67,14 @@ public class ServiceInstanceController extends BaseController {
 		return new ResponseEntity<>(response, getCreateResponseCode(response));
 	}
 
+	@RequestMapping(value = "/{foundationId}/v2/service_instances/{instanceId}", method = RequestMethod.PUT)
+	public ResponseEntity<?> createServiceInstance(@PathVariable(value = "foundationId") String foundationId,
+												   @PathVariable("instanceId") String serviceInstanceId,
+												   @Valid @RequestBody CreateServiceInstanceRequest request,
+												   @RequestParam(value = "accepts_incomplete", required = false) boolean acceptsIncomplete) {
+		return createServiceInstance(serviceInstanceId, request.withFoundationId(foundationId), acceptsIncomplete);
+	}
+
 	private HttpStatus getCreateResponseCode(CreateServiceInstanceResponse response) {
 		if (response.isAsync()) {
 			return HttpStatus.ACCEPTED;
@@ -78,7 +85,7 @@ public class ServiceInstanceController extends BaseController {
 		}
 	}
 
-	@RequestMapping(value = "/last_operation", method = RequestMethod.GET)
+	@RequestMapping(value = "/v2/service_instances/{instanceId}/last_operation", method = RequestMethod.GET)
 	public ResponseEntity<?> getServiceInstanceLastOperation(@PathVariable("instanceId") String serviceInstanceId) {
 
 		log.debug("Getting service instance status: serviceInstanceId=" + serviceInstanceId);
@@ -96,7 +103,27 @@ public class ServiceInstanceController extends BaseController {
 		return new ResponseEntity<>(response, isSuccessfulDelete ? HttpStatus.GONE : HttpStatus.OK);
 	}
 
-	@RequestMapping(method = RequestMethod.DELETE)
+	@RequestMapping(value = "/{foundationId}/v2/service_instances/{instanceId}", method = RequestMethod.DELETE)
+	public ResponseEntity<?> deleteServiceInstance(@PathVariable("foundationId") String foundationId,
+												   @PathVariable("instanceId") String serviceInstanceId,
+												   @RequestParam("service_id") String serviceDefinitionId,
+												   @RequestParam("plan_id") String planId,
+												   @RequestParam(value = "accepts_incomplete", required = false) boolean acceptsIncomplete) {
+		log.debug("Deleting a service instance: "
+				+ "serviceInstanceId=" + serviceInstanceId
+				+ ", serviceDefinitionId=" + serviceDefinitionId
+				+ ", planId=" + planId
+				+ ", foundationId=" + foundationId
+				+ ", acceptsIncomplete=" + acceptsIncomplete);
+
+		DeleteServiceInstanceRequest request =
+				new DeleteServiceInstanceRequest(serviceInstanceId, serviceDefinitionId, planId,
+						getServiceDefinition(serviceDefinitionId), acceptsIncomplete);
+
+		return deleteServiceInstance(serviceInstanceId, request.withFoundationId(foundationId));
+	}
+
+	@RequestMapping(value = "/v2/service_instances/{instanceId}", method = RequestMethod.DELETE)
 	public ResponseEntity<?> deleteServiceInstance(@PathVariable("instanceId") String serviceInstanceId,
 												   @RequestParam("service_id") String serviceDefinitionId,
 												   @RequestParam("plan_id") String planId,
@@ -107,11 +134,15 @@ public class ServiceInstanceController extends BaseController {
 				+ ", planId=" + planId
 				+ ", acceptsIncomplete=" + acceptsIncomplete);
 
-		try {
-			DeleteServiceInstanceRequest request =
-					new DeleteServiceInstanceRequest(serviceInstanceId, serviceDefinitionId, planId,
-							getServiceDefinition(serviceDefinitionId), acceptsIncomplete);
+		DeleteServiceInstanceRequest request =
+				new DeleteServiceInstanceRequest(serviceInstanceId, serviceDefinitionId, planId,
+						getServiceDefinition(serviceDefinitionId), acceptsIncomplete);
 
+		return deleteServiceInstance(serviceInstanceId, request);
+	}
+
+	private ResponseEntity<?> deleteServiceInstance(String serviceInstanceId, DeleteServiceInstanceRequest request) {
+		try {
 			DeleteServiceInstanceResponse response = service.deleteServiceInstance(request);
 
 			log.debug("Deleting a service instance succeeded: "
@@ -124,7 +155,15 @@ public class ServiceInstanceController extends BaseController {
 		}
 	}
 
-	@RequestMapping(method = RequestMethod.PATCH)
+	@RequestMapping(value = "/{foundationId}/v2/service_instances/{instanceId}", method = RequestMethod.PATCH)
+	public ResponseEntity<String> updateServiceInstance(@PathVariable("foundationId") String foundationId,
+														@PathVariable("instanceId") String serviceInstanceId,
+														@Valid @RequestBody UpdateServiceInstanceRequest request,
+														@RequestParam(value = "accepts_incomplete", required = false) boolean acceptsIncomplete) {
+		return updateServiceInstance(serviceInstanceId, request.withFoundationId(foundationId), acceptsIncomplete);
+	}
+
+	@RequestMapping(value = "/v2/service_instances/{instanceId}", method = RequestMethod.PATCH)
 	public ResponseEntity<String> updateServiceInstance(@PathVariable("instanceId") String serviceInstanceId,
 														@Valid @RequestBody UpdateServiceInstanceRequest request,
 														@RequestParam(value = "accepts_incomplete", required = false) boolean acceptsIncomplete) {

--- a/src/main/java/org/springframework/cloud/servicebroker/model/CreateServiceInstanceBindingRequest.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/model/CreateServiceInstanceBindingRequest.java
@@ -74,6 +74,13 @@ public class CreateServiceInstanceBindingRequest {
 	private transient String serviceInstanceId;
 
 	/**
+	 * The Cloud Foundry Foundation ID used to identify the foundation instance by a nested route in a
+	 * multi-cloud scenario.
+	 */
+	@JsonIgnore
+	private transient String foundationId;
+
+	/**
 	 * The Cloud Controller GUID of the service binding being created. This ID will be used for future
 	 * requests for the same service instance binding, so the broker must use it to correlate any resource it creates.
 	 */
@@ -147,5 +154,10 @@ public class CreateServiceInstanceBindingRequest {
 			return null;
 		}
 		return (String) bindResource.get(ServiceBindingResource.BIND_RESOURCE_KEY_ROUTE.toString());
+	}
+
+	public CreateServiceInstanceBindingRequest withFoundationId(String foundationId) {
+		this.foundationId = foundationId;
+		return this;
 	}
 }

--- a/src/main/java/org/springframework/cloud/servicebroker/model/CreateServiceInstanceRequest.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/model/CreateServiceInstanceRequest.java
@@ -64,6 +64,13 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 	private transient String serviceInstanceId;
 
 	/**
+	 * The Cloud Foundry Foundation ID used to identify the foundation instance by a nested route in a
+	 * multi-cloud scenario.
+	 */
+	@JsonIgnore
+	private transient String foundationId;
+
+	/**
 	 * The {@link ServiceDefinition} of the service to provision. This is resolved from the
 	 * <code>serviceDefinitionId</code> as a convenience to the broker.
 	 */
@@ -76,6 +83,7 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 		this.planId = null;
 		this.organizationGuid = null;
 		this.spaceGuid = null;
+		this.foundationId = null;
 	}
 	
 	public CreateServiceInstanceRequest(String serviceDefinitionId, String planId,
@@ -95,6 +103,11 @@ public class CreateServiceInstanceRequest extends AsyncParameterizedServiceInsta
 
 	public CreateServiceInstanceRequest withServiceDefinition(ServiceDefinition serviceDefinition) {
 		this.serviceDefinition = serviceDefinition;
+		return this;
+	}
+
+	public CreateServiceInstanceRequest withFoundationId(String foundationId) {
+		this.foundationId = foundationId;
 		return this;
 	}
 

--- a/src/main/java/org/springframework/cloud/servicebroker/model/DeleteServiceInstanceBindingRequest.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/model/DeleteServiceInstanceBindingRequest.java
@@ -28,6 +28,7 @@ public class DeleteServiceInstanceBindingRequest {
 	private final String serviceDefinitionId;
 	private final String planId;
 	private transient final ServiceDefinition serviceDefinition;
+	private transient String foundationId;
 
 	public DeleteServiceInstanceBindingRequest(String serviceInstanceId, String bindingId,
 											   String serviceDefinitionId, String planId,
@@ -37,5 +38,10 @@ public class DeleteServiceInstanceBindingRequest {
 		this.serviceDefinitionId = serviceDefinitionId;
 		this.planId = planId;
 		this.serviceDefinition = serviceDefinition;
+	}
+
+	public DeleteServiceInstanceBindingRequest withFoundationId(String foundationId) {
+		this.foundationId = foundationId;
+		return this;
 	}
 }

--- a/src/main/java/org/springframework/cloud/servicebroker/model/DeleteServiceInstanceRequest.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/model/DeleteServiceInstanceRequest.java
@@ -1,5 +1,6 @@
 package org.springframework.cloud.servicebroker.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -34,6 +35,14 @@ public class DeleteServiceInstanceRequest extends AsyncServiceInstanceRequest {
 	 */
 	private transient final ServiceDefinition serviceDefinition;
 
+	/**
+	 * The Cloud Foundry Foundation ID used to identify the foundation instance in a multi-cloud scenario.
+	 * This is optionally resolved from the <code>cfId</code> as a convenience to the broker.
+	 */
+	@JsonIgnore
+	private transient String foundationId;
+
+
 	public DeleteServiceInstanceRequest(String instanceId, String serviceId,
 										String planId, ServiceDefinition serviceDefinition,
 										boolean asyncAccepted) {
@@ -51,6 +60,11 @@ public class DeleteServiceInstanceRequest extends AsyncServiceInstanceRequest {
 
 	public DeleteServiceInstanceRequest withAsyncAccepted(boolean asyncAccepted) {
 		this.asyncAccepted = asyncAccepted;
+		return this;
+	}
+
+	public DeleteServiceInstanceRequest withFoundationId(String foundationId) {
+		this.foundationId = foundationId;
 		return this;
 	}
 }

--- a/src/main/java/org/springframework/cloud/servicebroker/model/UpdateServiceInstanceRequest.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/model/UpdateServiceInstanceRequest.java
@@ -51,10 +51,18 @@ public class UpdateServiceInstanceRequest  extends AsyncParameterizedServiceInst
 	@JsonIgnore
 	private transient ServiceDefinition serviceDefinition;
 
+	/**
+	 * The Cloud Foundry Foundation ID used to identify the foundation instance in a multi-cloud scenario.
+	 * This is optionally resolved from the <code>cfId</code> as a convenience to the broker.
+	 */
+	@JsonIgnore
+	private transient String foundationId;
+
 	public UpdateServiceInstanceRequest() {
 		super(null);
 		this.serviceDefinitionId = null;
 		this.planId = null;
+		this.foundationId = null;
 	}
 	
 	public UpdateServiceInstanceRequest(String serviceDefinitionId, String planId,
@@ -80,6 +88,11 @@ public class UpdateServiceInstanceRequest  extends AsyncParameterizedServiceInst
 
 	public UpdateServiceInstanceRequest withAsyncAccepted(boolean asyncAccepted) {
 		this.asyncAccepted = asyncAccepted;
+		return this;
+	}
+
+	public UpdateServiceInstanceRequest withFoundationId(String foundationId) {
+		this.foundationId = foundationId;
 		return this;
 	}
 }

--- a/src/test/java/org/springframework/cloud/servicebroker/controller/CatalogControllerIntegrationTest.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/controller/CatalogControllerIntegrationTest.java
@@ -111,4 +111,30 @@ public class CatalogControllerIntegrationTest {
 				.andExpect(jsonPath("$.services", empty()));
 	}
 
+
+	@Test
+	public void catalogIsRetrievedCorrectlyWithFoundationId() throws Exception {
+		when(catalogService.getCatalog()).thenReturn(getCatalog());
+
+		ServiceDefinition service = ServiceFixture.getSimpleService();
+		List<Plan> plans = PlanFixture.getAllPlans();
+
+		this.mockMvc.perform(get("/123/v2/catalog")
+				.accept(MediaType.APPLICATION_JSON))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.services.", hasSize(1)))
+				.andExpect(jsonPath("$.services[*].id", contains(service.getId())))
+				.andExpect(jsonPath("$.services[*].name", contains(service.getName())))
+				.andExpect(jsonPath("$.services[*].description", contains(service.getDescription())))
+				.andExpect(jsonPath("$.services[*].bindable", contains(service.isBindable())))
+				.andExpect(jsonPath("$.services[*].plan_updateable", contains(service.isPlanUpdateable())))
+				.andExpect(jsonPath("$.services[*].requires[*]", empty()))
+				.andExpect(jsonPath("$.services[*].plans[*].id", containsInAnyOrder(plans.get(0).getId(), plans.get(1).getId())))
+				.andExpect(jsonPath("$.services[*].plans[*].name", containsInAnyOrder(plans.get(0).getName(), plans.get(1).getName())))
+				.andExpect(jsonPath("$.services[*].plans[*].description", containsInAnyOrder(plans.get(0).getDescription(), plans.get(1).getDescription())))
+				.andExpect(jsonPath("$.services[*].plans[*].metadata", containsInAnyOrder(Collections.EMPTY_MAP, plans.get(1).getMetadata())));
+	}
+
 }

--- a/src/test/java/org/springframework/cloud/servicebroker/controller/NonBindableServiceInstanceBindingControllerIntegrationTest.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/controller/NonBindableServiceInstanceBindingControllerIntegrationTest.java
@@ -35,7 +35,7 @@ public class NonBindableServiceInstanceBindingControllerIntegrationTest extends 
 	public void createBindingToAppFails() throws Exception {
 		setupCatalogService(createRequest.getServiceDefinitionId());
 
-		mockMvc.perform(put(buildUrl(createRequest))
+		mockMvc.perform(put(buildUrl(createRequest, false))
 				.content(DataFixture.toJson(createRequest))
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON))
@@ -46,7 +46,7 @@ public class NonBindableServiceInstanceBindingControllerIntegrationTest extends 
 	public void deleteBindingFails() throws Exception {
 		setupCatalogService(deleteRequest.getServiceDefinitionId());
 
-		mockMvc.perform(delete(buildUrl(deleteRequest))
+		mockMvc.perform(delete(buildUrl(deleteRequest, false))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isInternalServerError());
 	}

--- a/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingControllerIntegrationTest.java
@@ -1,11 +1,13 @@
 package org.springframework.cloud.servicebroker.controller;
 
+import org.mockito.ArgumentCaptor;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingDoesNotExistException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import org.springframework.cloud.servicebroker.model.CreateServiceInstanceBindingRequest;
 import org.springframework.cloud.servicebroker.model.CreateServiceInstanceAppBindingResponse;
 import org.springframework.cloud.servicebroker.model.CreateServiceInstanceRouteBindingResponse;
+import org.springframework.cloud.servicebroker.model.DeleteServiceInstanceBindingRequest;
 import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingService;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,6 +26,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -59,7 +62,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 
 		setupCatalogService(createRequest.getServiceDefinitionId());
 
-		mockMvc.perform(put(buildUrl(createRequest))
+		mockMvc.perform(put(buildUrl(createRequest, false))
 				.content(DataFixture.toJson(createRequest))
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON))
@@ -69,6 +72,31 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 				.andExpect(jsonPath("$.credentials.password", is(createResponse.getCredentials().get("password"))))
 				.andExpect(jsonPath("$.syslog_drain_url", nullValue()))
 				.andExpect(jsonPath("$.route_service_url", nullValue()));
+	}
+
+	@Test
+	public void createBindingToAppWithFoundationIdSucceeds() throws Exception {
+		CreateServiceInstanceAppBindingResponse createResponse = ServiceInstanceBindingFixture.buildCreateAppBindingResponse();
+
+		when(serviceInstanceBindingService.createServiceInstanceBinding(eq(createRequest)))
+				.thenReturn(createResponse);
+
+		setupCatalogService(createRequest.getServiceDefinitionId());
+
+		mockMvc.perform(put(buildUrl(createRequest, true))
+				.content(DataFixture.toJson(createRequest))
+				.accept(MediaType.APPLICATION_JSON)
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.credentials.uri", is(createResponse.getCredentials().get("uri"))))
+				.andExpect(jsonPath("$.credentials.username", is(createResponse.getCredentials().get("username"))))
+				.andExpect(jsonPath("$.credentials.password", is(createResponse.getCredentials().get("password"))))
+				.andExpect(jsonPath("$.syslog_drain_url", nullValue()))
+				.andExpect(jsonPath("$.route_service_url", nullValue()));
+
+		ArgumentCaptor<CreateServiceInstanceBindingRequest> argumentCaptor = ArgumentCaptor.forClass(CreateServiceInstanceBindingRequest.class);
+		verify(serviceInstanceBindingService).createServiceInstanceBinding(argumentCaptor.capture());
+		assertEquals("123", argumentCaptor.getValue().getFoundationId());
 	}
 
 	@Test
@@ -82,7 +110,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 
 		setupCatalogService(createRequest.getServiceDefinitionId());
 
-		mockMvc.perform(put(buildUrl(createRequest))
+		mockMvc.perform(put(buildUrl(createRequest, false))
 				.content(DataFixture.toJson(createRequest))
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON))
@@ -103,7 +131,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 
 		setupCatalogService(request.getServiceDefinitionId());
 
-		mockMvc.perform(put(buildUrl(request))
+		mockMvc.perform(put(buildUrl(request, false))
 				.content(DataFixture.toJson(request))
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON))
@@ -124,7 +152,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 
 		setupCatalogService(request.getServiceDefinitionId());
 
-		mockMvc.perform(put(buildUrl(request))
+		mockMvc.perform(put(buildUrl(request, false))
 				.content(DataFixture.toJson(request))
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON))
@@ -142,7 +170,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 
 		setupCatalogService(createRequest.getServiceDefinitionId());
 
-		mockMvc.perform(put(buildUrl(createRequest))
+		mockMvc.perform(put(buildUrl(createRequest, false))
 				.content(DataFixture.toJson(createRequest))
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON))
@@ -161,7 +189,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 
 		setupCatalogService(createRequest.getServiceDefinitionId());
 
-		mockMvc.perform(put(buildUrl(createRequest))
+		mockMvc.perform(put(buildUrl(createRequest, false))
 				.content(DataFixture.toJson(createRequest))
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON))
@@ -179,7 +207,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 		when(catalogService.getServiceDefinition(eq(createRequest.getServiceDefinitionId())))
 				.thenReturn(null);
 
-		mockMvc.perform(put(buildUrl(createRequest))
+		mockMvc.perform(put(buildUrl(createRequest, false))
 				.content(DataFixture.toJson(createRequest))
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON))
@@ -193,7 +221,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 
 		setupCatalogService(createRequest.getServiceDefinitionId());
 
-		mockMvc.perform(put(buildUrl(createRequest))
+		mockMvc.perform(put(buildUrl(createRequest, false))
 				.content(DataFixture.toJson(createRequest))
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON))
@@ -207,7 +235,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 		String body = DataFixture.toJson(createRequest);
 		body = body.replace("service_id", "foo");
 
-		mockMvc.perform(put(buildUrl(createRequest))
+		mockMvc.perform(put(buildUrl(createRequest, false))
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(body))
 				.andExpect(status().isUnprocessableEntity())
@@ -218,7 +246,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 	public void createBindingWithMissingFieldsFails() throws Exception {
 		String body = "{}";
 
-		mockMvc.perform(put(buildUrl(createRequest))
+		mockMvc.perform(put(buildUrl(createRequest, false))
 				.content(body)
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON))
@@ -231,12 +259,26 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 	public void deleteBindingSucceeds() throws Exception {
 		setupCatalogService(deleteRequest.getServiceDefinitionId());
 
-		mockMvc.perform(delete(buildUrl(deleteRequest))
+		mockMvc.perform(delete(buildUrl(deleteRequest, false))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$", is("{}")));
 
 		verify(serviceInstanceBindingService).deleteServiceInstanceBinding(eq(deleteRequest));
+	}
+
+	@Test
+	public void deleteBindingWithFoundationIdSucceeds() throws Exception {
+		setupCatalogService(deleteRequest.getServiceDefinitionId());
+
+		mockMvc.perform(delete(buildUrl(deleteRequest, true))
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$", is("{}")));
+
+		ArgumentCaptor<DeleteServiceInstanceBindingRequest> argumentCaptor = ArgumentCaptor.forClass(DeleteServiceInstanceBindingRequest.class);
+		verify(serviceInstanceBindingService).deleteServiceInstanceBinding(argumentCaptor.capture());
+		assertEquals("123", argumentCaptor.getValue().getFoundationId());
 	}
 
 	@Test
@@ -246,7 +288,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 
 		setupCatalogService(deleteRequest.getServiceDefinitionId());
 
-		mockMvc.perform(delete(buildUrl(deleteRequest))
+		mockMvc.perform(delete(buildUrl(deleteRequest, false))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isUnprocessableEntity())
 				.andExpect(jsonPath("$.description", containsString(deleteRequest.getServiceInstanceId())));
@@ -259,7 +301,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 
 		setupCatalogService(deleteRequest.getServiceDefinitionId());
 
-		mockMvc.perform(delete(buildUrl(deleteRequest))
+		mockMvc.perform(delete(buildUrl(deleteRequest, false))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isGone())
 				.andExpect(jsonPath("$", is("{}")));
@@ -270,7 +312,7 @@ public class ServiceInstanceBindingControllerIntegrationTest extends ServiceInst
 		when(catalogService.getServiceDefinition(eq(deleteRequest.getServiceDefinitionId())))
 				.thenReturn(null);
 
-		mockMvc.perform(delete(buildUrl(deleteRequest))
+		mockMvc.perform(delete(buildUrl(deleteRequest, false))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 	}

--- a/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingIntegrationTest.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceBindingIntegrationTest.java
@@ -8,6 +8,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 public abstract class ServiceInstanceBindingIntegrationTest extends ControllerIntegrationTest {
 	protected UriComponentsBuilder uriBuilder;
+	protected UriComponentsBuilder foundationIdUriBuilder;
 
 	protected CreateServiceInstanceBindingRequest createRequest;
 	protected DeleteServiceInstanceBindingRequest deleteRequest;
@@ -16,18 +17,22 @@ public abstract class ServiceInstanceBindingIntegrationTest extends ControllerIn
 	public void setupBase() {
 		uriBuilder = UriComponentsBuilder.fromPath("/v2/service_instances/")
 				.pathSegment("service-instance-one-id", "service_bindings");
+		foundationIdUriBuilder = UriComponentsBuilder.fromPath("/123/v2/service_instances/")
+				.pathSegment("service-instance-one-id", "service_bindings");
 
 		createRequest = ServiceInstanceBindingFixture.buildCreateAppBindingRequest();
 
 		deleteRequest = ServiceInstanceBindingFixture.buildDeleteServiceInstanceBindingRequest();
 	}
 
-	protected String buildUrl(CreateServiceInstanceBindingRequest request) {
-		return uriBuilder.path(request.getBindingId()).toUriString();
+	protected String buildUrl(CreateServiceInstanceBindingRequest request, Boolean withFoundationId) {
+		UriComponentsBuilder builder = withFoundationId ? foundationIdUriBuilder : uriBuilder;
+		return builder.path(request.getBindingId()).toUriString();
 	}
 
-	protected String buildUrl(DeleteServiceInstanceBindingRequest request) {
-		return uriBuilder.path(request.getBindingId())
+	protected String buildUrl(DeleteServiceInstanceBindingRequest request, Boolean withFoundationId) {
+		UriComponentsBuilder builder = withFoundationId ? foundationIdUriBuilder : uriBuilder;
+		return builder.path(request.getBindingId())
 				.queryParam("service_id", request.getServiceDefinitionId())
 				.queryParam("plan_id", request.getPlanId())
 				.toUriString();


### PR DESCRIPTION
This PR adds new routes to instance & binding controllers to identify a Cloud Foundry instance using a foundation-administrator provided ID.  The foundation ID is enabled by registering the service broker using the following syntax:

```shell-session
$ cf create-service-broker <broker-name> <username> <password> https://<broker-url>/<foundation-id>
```

This PR maintains backward compatibility. If a broker is registered "normally", the foundationId attribute will simply be set to null in the request.

This PR also closes #15 

Thanks!