### PR TITLE
Support service broker API version 2.9

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ This project replaces https://github.com/cloudfoundry-community/spring-boot-cf-s
 
 == Compatibility
 
-* http://docs.cloudfoundry.org/services/api.html[Service Broker API]: 2.8
+* http://docs.cloudfoundry.org/services/api.html[Service Broker API]: 2.9
 
 == Getting Started
 

--- a/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceController.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceController.java
@@ -86,11 +86,19 @@ public class ServiceInstanceController extends BaseController {
 	}
 
 	@RequestMapping(value = "/v2/service_instances/{instanceId}/last_operation", method = RequestMethod.GET)
-	public ResponseEntity<?> getServiceInstanceLastOperation(@PathVariable("instanceId") String serviceInstanceId) {
+	public ResponseEntity<?> getServiceInstanceLastOperation(@PathVariable("instanceId") String serviceInstanceId,
+															 @RequestParam("service_id") String serviceDefinitionId,
+															 @RequestParam("plan_id") String planId,
+															 @RequestParam(value = "operation", required = false) String operation) {
 
-		log.debug("Getting service instance status: serviceInstanceId={}", serviceInstanceId);
+		log.debug("Getting service instance status: serviceInstanceId={}, serviceDefinitionId={}, planId={}, operation={}",
+				serviceInstanceId,
+				serviceDefinitionId,
+				planId,
+				operation);
 
-		GetLastServiceOperationRequest request = new GetLastServiceOperationRequest(serviceInstanceId);
+		GetLastServiceOperationRequest request = new GetLastServiceOperationRequest(serviceInstanceId, serviceDefinitionId, planId);
+		request.withOperation(operation);
 
 		GetLastServiceOperationResponse response = service.getLastOperation(request);
 
@@ -143,7 +151,7 @@ public class ServiceInstanceController extends BaseController {
 
 			log.debug("Deleting a service instance succeeded: serviceInstanceId={}", serviceInstanceId);
 
-			return new ResponseEntity<>("{}", response.isAsync() ? HttpStatus.ACCEPTED : HttpStatus.OK);
+			return new ResponseEntity<>(response, response.isAsync() ? HttpStatus.ACCEPTED : HttpStatus.OK);
 		} catch (ServiceInstanceDoesNotExistException e) {
 			log.debug("Service instance does not exist: ", e);
 			return new ResponseEntity<>("{}", HttpStatus.GONE);
@@ -151,7 +159,7 @@ public class ServiceInstanceController extends BaseController {
 	}
 
 	@RequestMapping(value = "/{foundationId}/v2/service_instances/{instanceId}", method = RequestMethod.PATCH)
-	public ResponseEntity<String> updateServiceInstance(@PathVariable("foundationId") String foundationId,
+	public ResponseEntity<?> updateServiceInstance(@PathVariable("foundationId") String foundationId,
 														@PathVariable("instanceId") String serviceInstanceId,
 														@Valid @RequestBody UpdateServiceInstanceRequest request,
 														@RequestParam(value = "accepts_incomplete", required = false) boolean acceptsIncomplete) {
@@ -159,7 +167,7 @@ public class ServiceInstanceController extends BaseController {
 	}
 
 	@RequestMapping(value = "/v2/service_instances/{instanceId}", method = RequestMethod.PATCH)
-	public ResponseEntity<String> updateServiceInstance(@PathVariable("instanceId") String serviceInstanceId,
+	public ResponseEntity<?> updateServiceInstance(@PathVariable("instanceId") String serviceInstanceId,
 														@Valid @RequestBody UpdateServiceInstanceRequest request,
 														@RequestParam(value = "accepts_incomplete", required = false) boolean acceptsIncomplete) {
 		if (log.isDebugEnabled()) {
@@ -176,7 +184,7 @@ public class ServiceInstanceController extends BaseController {
 
 		log.debug("Updating a service instance succeeded: serviceInstanceId={}", serviceInstanceId);
 
-		return new ResponseEntity<>("{}", response.isAsync() ? HttpStatus.ACCEPTED : HttpStatus.OK);
+		return new ResponseEntity<>(response, response.isAsync() ? HttpStatus.ACCEPTED : HttpStatus.OK);
 	}
 
 	@ExceptionHandler(ServiceInstanceExistsException.class)

--- a/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceInstanceResponse.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/model/AsyncServiceInstanceResponse.java
@@ -1,5 +1,8 @@
 package org.springframework.cloud.servicebroker.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -12,11 +15,23 @@ import lombok.ToString;
 @Getter
 @ToString
 @EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class AsyncServiceInstanceResponse {
-	/**
-	 * Indicates whether the request to the service broker is complete. A <code>false</code> value indicates that the
-	 * request was completed, a <code>true</code> value indicates that the broker is processing the request
-	 * asynchronously.
-	 */
-	protected boolean async = false;
+    /**
+     * Indicates whether the request to the service broker is complete. A <code>false</code> value indicates that the
+     * request was completed, a <code>true</code> value indicates that the broker is processing the request
+     * asynchronously.
+     */
+    @JsonIgnore
+    protected boolean async = false;
+
+
+    /**
+     * For async responses, service brokers can return operation state as a string. This field will be provided back to
+     * the service broker on last_operation requests as a URL encoded query param. Can be <code>null</code> to indicate
+     * that an operation state is not provided.
+     */
+    @JsonSerialize
+    protected String operation;
+
 }

--- a/src/main/java/org/springframework/cloud/servicebroker/model/BrokerApiVersion.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/model/BrokerApiVersion.java
@@ -12,7 +12,7 @@ public class BrokerApiVersion {
 
 	public final static String DEFAULT_API_VERSION_HEADER = "X-Broker-Api-Version";
 	public final static String API_VERSION_ANY = "*";
-	public final static String API_VERSION_CURRENT = "2.8";
+	public final static String API_VERSION_CURRENT = "2.9";
 
 	/**
 	 * The name of the HTTP header field expected to contain the API version of the service broker client.

--- a/src/main/java/org/springframework/cloud/servicebroker/model/CreateServiceInstanceResponse.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/model/CreateServiceInstanceResponse.java
@@ -47,4 +47,9 @@ public class CreateServiceInstanceResponse extends AsyncServiceInstanceResponse 
 		this.async = async;
 		return this;
 	}
+
+	public CreateServiceInstanceResponse withOperation(final String operation) {
+		this.operation = operation;
+		return this;
+	}
 }

--- a/src/main/java/org/springframework/cloud/servicebroker/model/DeleteServiceInstanceResponse.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/model/DeleteServiceInstanceResponse.java
@@ -17,4 +17,9 @@ public class DeleteServiceInstanceResponse extends AsyncServiceInstanceResponse 
 		this.async = async;
 		return this;
 	}
+
+	public DeleteServiceInstanceResponse withOperation(final String operation) {
+		this.operation = operation;
+		return this;
+	}
 }

--- a/src/main/java/org/springframework/cloud/servicebroker/model/GetLastServiceOperationRequest.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/model/GetLastServiceOperationRequest.java
@@ -18,7 +18,32 @@ public class GetLastServiceOperationRequest {
 	 */
 	private final String serviceInstanceId;
 
-	public GetLastServiceOperationRequest(String serviceInstanceId) {
-		this.serviceInstanceId = serviceInstanceId;
+	/**
+	 * The ID of the service to deprovision, from the broker catalog.
+	 */
+	private final String serviceDefinitionId;
+
+	/**
+	 * The ID of the plan to deprovision within the service, from the broker catalog.
+	 */
+	private final String planId;
+
+	/**
+	 * The field optionally returned by the service broker on Provision, Update, Deprovision async responses.
+	 * Represents any state the service broker responsed with as a URL encoded string. Can be <code>null</code>
+	 * to indicate that an operation state is not provided.
+	 */
+	protected String operation;
+
+	public GetLastServiceOperationRequest(String instanceId, String serviceId, String planId) {
+		this.serviceInstanceId = instanceId;
+		this.serviceDefinitionId = serviceId;
+		this.planId = planId;
 	}
+
+	public GetLastServiceOperationRequest withOperation(final String operation) {
+		this.operation = operation;
+		return this;
+	}
+
 }

--- a/src/main/java/org/springframework/cloud/servicebroker/model/UpdateServiceInstanceResponse.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/model/UpdateServiceInstanceResponse.java
@@ -17,4 +17,9 @@ public class UpdateServiceInstanceResponse extends AsyncServiceInstanceResponse 
 		this.async = async;
 		return this;
 	}
+
+	public UpdateServiceInstanceResponse withOperation(final String operation) {
+		this.operation = operation;
+		return this;
+	}
 }

--- a/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerIntegrationTest.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/controller/ServiceInstanceControllerIntegrationTest.java
@@ -140,7 +140,8 @@ public class ServiceInstanceControllerIntegrationTest extends ControllerIntegrat
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isAccepted())
-				.andExpect(jsonPath("$.dashboard_url", is(asyncCreateResponse.getDashboardUrl())));
+				.andExpect(jsonPath("$.dashboard_url", is(asyncCreateResponse.getDashboardUrl())))
+ 		        .andExpect(jsonPath("$.operation", is(asyncCreateResponse.getOperation())));
 	}
 
 	@Test
@@ -263,7 +264,8 @@ public class ServiceInstanceControllerIntegrationTest extends ControllerIntegrat
 
 		mockMvc.perform(delete(buildUrl(syncDeleteRequest, false))
 				.accept(MediaType.APPLICATION_JSON))
-				.andExpect(status().isOk());
+				.andExpect(status().isOk())
+				.andExpect(content().string("{}"));
 	}
 
 	@Test
@@ -291,7 +293,8 @@ public class ServiceInstanceControllerIntegrationTest extends ControllerIntegrat
 
 		mockMvc.perform(delete(buildUrl(asyncDeleteRequest, false))
 				.accept(MediaType.APPLICATION_JSON))
-				.andExpect(status().isAccepted());
+				.andExpect(status().isAccepted())
+				.andExpect(jsonPath("$.operation", is(asyncDeleteResponse.getOperation())));
 	}
 
 	@Test
@@ -346,7 +349,7 @@ public class ServiceInstanceControllerIntegrationTest extends ControllerIntegrat
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$", is("{}")));
+				.andExpect(content().string("{}"));
 	}
 
 	@Test
@@ -361,7 +364,7 @@ public class ServiceInstanceControllerIntegrationTest extends ControllerIntegrat
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$", is("{}")));
+				.andExpect(content().string("{}"));
 
 		ArgumentCaptor<UpdateServiceInstanceRequest> argumentCaptor = ArgumentCaptor.forClass(UpdateServiceInstanceRequest.class);
 		Mockito.verify(serviceInstanceService).updateServiceInstance(argumentCaptor.capture());
@@ -380,7 +383,7 @@ public class ServiceInstanceControllerIntegrationTest extends ControllerIntegrat
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isAccepted())
-				.andExpect(jsonPath("$", is("{}")));
+				.andExpect(jsonPath("$.operation", is(asyncUpdateResponse.getOperation())));
 	}
 
 	@Test
@@ -539,6 +542,10 @@ public class ServiceInstanceControllerIntegrationTest extends ControllerIntegrat
 
 	private String buildUrl(GetLastServiceOperationRequest request, Boolean withFoundationId) {
 		UriComponentsBuilder builder = withFoundationId ? foundationIdUriBuilder : uriBuilder;
-		return builder.pathSegment(request.getServiceInstanceId(), "last_operation").toUriString();
+		return builder.pathSegment(request.getServiceInstanceId(), "last_operation")
+				.queryParam("service_id", request.getServiceDefinitionId())
+				.queryParam("plan_id", request.getPlanId())
+				.queryParam("operation", request.getOperation())
+				.toUriString();
 	}
 }

--- a/src/test/java/org/springframework/cloud/servicebroker/model/fixture/ServiceInstanceFixture.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/model/fixture/ServiceInstanceFixture.java
@@ -24,9 +24,10 @@ public class ServiceInstanceFixture {
 	}
 
 	public static CreateServiceInstanceResponse buildCreateServiceInstanceResponse(boolean async) {
-		return new CreateServiceInstanceResponse()
+		final CreateServiceInstanceResponse response = new CreateServiceInstanceResponse()
 				.withDashboardUrl("https://dashboard_url.example.com")
 				.withAsync(async);
+		return response.isAsync() ? response.withOperation("task_10") : response;
 	}
 
 	public static DeleteServiceInstanceRequest buildDeleteServiceInstanceRequest(boolean acceptsIncomplete) {
@@ -39,7 +40,8 @@ public class ServiceInstanceFixture {
 	}
 
 	public static DeleteServiceInstanceResponse buildDeleteServiceInstanceResponse(boolean async) {
-		return new DeleteServiceInstanceResponse().withAsync(async);
+		final DeleteServiceInstanceResponse response = new DeleteServiceInstanceResponse().withAsync(async);
+        return response.isAsync() ? response.withOperation("task_10") : response;
 	}
 
 	public static UpdateServiceInstanceRequest buildUpdateServiceInstanceRequest(boolean acceptsIncomplete) {
@@ -53,10 +55,16 @@ public class ServiceInstanceFixture {
 	}
 
 	public static UpdateServiceInstanceResponse buildUpdateServiceInstanceResponse(boolean async) {
-		return new UpdateServiceInstanceResponse().withAsync(async);
+		final UpdateServiceInstanceResponse response = new UpdateServiceInstanceResponse().withAsync(async);
+        return response.isAsync() ? response.withOperation("task_10") : response;
 	}
 
 	public static GetLastServiceOperationRequest buildGetLastOperationRequest() {
-		return new GetLastServiceOperationRequest("service-instance-id");
+		ServiceDefinition service = ServiceFixture.getSimpleService();
+		return new GetLastServiceOperationRequest(
+				"service-instance-id",
+				service.getId(),
+				service.getPlans().get(0).getId())
+				.withOperation("task_10");
 	}
 }


### PR DESCRIPTION
- last_operation endpoint now supports service_id and plan_id as request parameters.
- Brokers may now optionally return operation field in responses for Provision, Update, and Deprovision.
  Broker clients may provide this same object as a request parameter when polling last operation.

[#19]
