### PR TITLE
Fix CreateServiceInstanceVolumeBindingResponse instances equality

### DIFF
--- a/src/main/java/org/springframework/cloud/servicebroker/model/VolumeDevice.java
+++ b/src/main/java/org/springframework/cloud/servicebroker/model/VolumeDevice.java
@@ -1,4 +1,7 @@
 package org.springframework.cloud.servicebroker.model;
 
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
 public class VolumeDevice {
 }

--- a/src/test/java/org/springframework/cloud/servicebroker/model/CreateServiceInstanceVolumeBindingResponseTest.java
+++ b/src/test/java/org/springframework/cloud/servicebroker/model/CreateServiceInstanceVolumeBindingResponseTest.java
@@ -1,0 +1,17 @@
+package org.springframework.cloud.servicebroker.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.cloud.servicebroker.model.fixture.ServiceInstanceBindingFixture;
+
+public class CreateServiceInstanceVolumeBindingResponseTest {
+
+    @Test
+    public void canEqual() throws Exception {
+        CreateServiceInstanceVolumeBindingResponse actual = ServiceInstanceBindingFixture.buildCreateBindingResponseForVolume();
+        CreateServiceInstanceVolumeBindingResponse expected = ServiceInstanceBindingFixture.buildCreateBindingResponseForVolume();
+
+        Assert.assertEquals(expected, actual);
+    }
+
+}


### PR DESCRIPTION
This fix enables to assert equality on CreateServiceInstanceVolumeBindingResponse instances

[#29]